### PR TITLE
Add owner analytics service for restaurant owners

### DIFF
--- a/src/routes/__init__.py
+++ b/src/routes/__init__.py
@@ -1,5 +1,6 @@
 from flask import Blueprint
 
+from src.routes.analytics_routes import analytics_bp
 from src.routes.auth_routes import auth_bp
 from src.routes.address_routes import addresses_bp
 from src.routes.report_routes import report_bp
@@ -30,5 +31,6 @@ def init_app(app):
     api_v1.register_blueprint(achievement_bp)
     api_v1.register_blueprint(restaurant_badge_bp)
     api_v1.register_blueprint(static_bp)
+    api_v1.register_blueprint(analytics_bp)
 
     app.register_blueprint(api_v1)

--- a/src/routes/analytics_routes.py
+++ b/src/routes/analytics_routes.py
@@ -1,0 +1,89 @@
+from flask import Blueprint, jsonify
+from flask_jwt_extended import jwt_required, get_jwt_identity
+from src.models import User
+from src.services.analytics_service import RestaurantAnalyticsService
+from functools import wraps
+
+analytics_bp = Blueprint('analytics', __name__)
+
+def owner_required(f):
+    """Decorator to check if the user has owner role"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        user_id = get_jwt_identity()
+        user = User.query.get(user_id)
+        if not user or user.role != 'owner':
+            return jsonify({
+                "success": False,
+                "message": "This endpoint is only available for restaurant owners"
+            }), 403
+        return f(*args, **kwargs)
+    return decorated_function
+
+@analytics_bp.route('/analytics/dashboard', methods=['GET'])
+@jwt_required()
+@owner_required
+def get_owner_analytics():
+    """
+    Get analytics dashboard data for restaurant owner
+    ---
+    tags:
+      - Analytics
+    security:
+      - BearerAuth: []
+    responses:
+      200:
+        description: Analytics dashboard data
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                success:
+                  type: boolean
+                data:
+                  type: object
+                  properties:
+                    monthly_stats:
+                      type: object
+                      properties:
+                        total_products_sold:
+                          type: integer
+                        total_revenue:
+                          type: string
+                        period:
+                          type: string
+                    regional_distribution:
+                      type: object
+                    restaurant_ratings:
+                      type: object
+                      additionalProperties:
+                        type: object
+                        properties:
+                          id:
+                            type: integer
+                          average_rating:
+                            type: number
+                          total_ratings:
+                            type: integer
+                          recent_comments:
+                            type: array
+                            items:
+                              type: object
+                              properties:
+                                user_name:
+                                  type: string
+                                rating:
+                                  type: number
+                                comment:
+                                  type: string
+                                timestamp:
+                                  type: string
+      403:
+        description: User is not a restaurant owner
+      404:
+        description: No restaurants found for this owner
+    """
+    owner_id = get_jwt_identity()
+    response, status_code = RestaurantAnalyticsService.get_owner_analytics(owner_id)
+    return jsonify(response), status_code

--- a/src/services/analytics_service.py
+++ b/src/services/analytics_service.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from sqlalchemy import func, and_
+from src.models import db, Restaurant, Purchase, PurchaseStatus, RestaurantComment
+from decimal import Decimal
+
+
+class RestaurantAnalyticsService:
+    @staticmethod
+    def get_owner_analytics(owner_id):
+        """Get analytics for all restaurants owned by the user"""
+        # Get the start date for current month
+        today = datetime.utcnow()
+        start_date = datetime(today.year, today.month, 1)
+
+        # Get all restaurants owned by the user
+        restaurants = Restaurant.query.filter_by(owner_id=owner_id).all()
+        restaurant_ids = [r.id for r in restaurants]
+
+        if not restaurant_ids:
+            return {
+                "success": False,
+                "message": "No restaurants found for this owner"
+            }, 404
+
+        # Get all completed purchases for the month
+        monthly_purchases = Purchase.query.filter(
+            Purchase.restaurant_id.in_(restaurant_ids),
+            Purchase.status == PurchaseStatus.COMPLETED,
+            Purchase.purchase_date >= start_date
+        ).all()
+
+        # Calculate monthly metrics
+        monthly_products = sum(p.quantity for p in monthly_purchases)
+        monthly_revenue = sum(Decimal(p.total_price) for p in monthly_purchases)
+
+        # Calculate regional distribution from delivery addresses
+        regions = {}
+        for purchase in monthly_purchases:
+            if purchase.delivery_address:
+                # Split address and get district/region
+                parts = purchase.delivery_address.split(',')
+                district = parts[2].strip() if len(parts) > 2 else 'Unknown'
+                regions[district] = regions.get(district, 0) + 1
+
+        # Get ratings and comments for all owner's restaurants
+        restaurant_stats = {}
+        for restaurant in restaurants:
+            comments = RestaurantComment.query.filter_by(restaurant_id=restaurant.id) \
+                .order_by(RestaurantComment.timestamp.desc()).all()
+
+            restaurant_stats[restaurant.restaurantName] = {
+                "id": restaurant.id,
+                "average_rating": float(restaurant.rating) if restaurant.rating else 0,
+                "total_ratings": restaurant.ratingCount,
+                "recent_comments": [{
+                    "user_name": comment.user.name,
+                    "rating": float(comment.rating),
+                    "comment": comment.comment,
+                    "timestamp": comment.timestamp.isoformat()
+                } for comment in comments[:5]]  # Get 5 most recent comments
+            }
+
+        return {
+            "success": True,
+            "data": {
+                "monthly_stats": {
+                    "total_products_sold": monthly_products,
+                    "total_revenue": str(monthly_revenue),
+                    "period": f"{today.year}-{today.month:02d}"
+                },
+                "regional_distribution": regions,
+                "restaurant_ratings": restaurant_stats
+            }
+        }, 200


### PR DESCRIPTION
- Introduced a new service function `get_owner_analytics_service` in `services/analytics_service.py`
- Aggregates analytics for restaurant owners by:
  - Retrieving all restaurants owned by the specified owner
  - Filtering purchases within the current month (based on accepted or completed status)
  - Calculating total products sold (sum of purchase quantities) and total revenue (sum of purchase total_price)
  - Determining the top region by joining CustomerAddress data with purchases (grouped by province, using the primary address)
  - Aggregating user comments and ratings for all restaurants owned by the owner
- Formats the output into a JSON response containing:
  - `total_products_sold`
  - `total_revenue`
  - `top_region`
  - `comments` (with restaurant ID, user ID, rating, comment text, and timestamp)
- Provides clear error responses when no restaurants are found for the owner